### PR TITLE
Fix: broadcast changes after updating status

### DIFF
--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -208,6 +208,7 @@ func (s *Strategy) doUpdate(ctx context.Context, obj types.Object, updateGenerat
 }
 
 func (s *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
+	defer s.broadcastChange()
 	return s.doUpdate(ctx, obj, false)
 }
 


### PR DESCRIPTION
We don't broadcast the changes after updating status, and this is causing the delay when using watch api to watch for status changes. It is notiable in multiple places where it is causing a significant delay when watching for multiple resources.

