### PR TITLE
feat: add field selector indexing

### DIFF
--- a/pkg/db/factory.go
+++ b/pkg/db/factory.go
@@ -40,16 +40,17 @@ func NewFactory(schema *runtime.Scheme, dsn string) (*Factory, error) {
 		pool                   bool
 		skipDefaultTransaction bool
 	)
-	if strings.HasPrefix(dsn, "sqlite://") {
+	switch {
+	case strings.HasPrefix(dsn, "sqlite://"):
 		skipDefaultTransaction = true
 		gdb = sqlite.Open(strings.TrimPrefix(dsn, "sqlite://"))
-	} else if strings.HasPrefix(dsn, "postgres://") {
+	case strings.HasPrefix(dsn, "postgresql://"):
+		dsn = strings.Replace(dsn, "postgresql://", "postgres://", 1)
+		fallthrough
+	case strings.HasPrefix(dsn, "postgres://"):
 		gdb = postgres.Open(dsn)
 		pool = true
-	} else if strings.HasPrefix(dsn, "postgresql://") {
-		gdb = postgres.Open(strings.Replace(dsn, "postgresql://", "postgres://", 1))
-		pool = true
-	} else {
+	default:
 		return nil, fmt.Errorf("unsupported database: %s", dsn)
 	}
 	db, err := gorm.Open(gdb, &gorm.Config{

--- a/pkg/db/listiter.go
+++ b/pkg/db/listiter.go
@@ -39,7 +39,7 @@ func newLister(ctx context.Context, db *db, namespace string, opts storage.ListO
 		}
 	}
 
-	listMeta, records, err := db.list(ctx, getNamespace(namespace), getName(opts), rev, after, cont, opts.Predicate.Limit)
+	listMeta, records, err := db.list(ctx, getNamespace(namespace), getName(opts), rev, after, cont, opts.Predicate.Limit, opts.Predicate.Field)
 	if err != nil {
 		return "", nil, err
 	}
@@ -66,7 +66,7 @@ func newLister(ctx context.Context, db *db, namespace string, opts storage.ListO
 			}
 
 			// Continue to paginate records
-			_, records, err = db.list(ctx, getNamespace(namespace), getName(opts), rev, false, records[len(records)-1].id, opts.Predicate.Limit)
+			_, records, err = db.list(ctx, getNamespace(namespace), getName(opts), rev, false, records[len(records)-1].id, opts.Predicate.Limit, opts.Predicate.Field)
 			if err != nil {
 				yield(record{}, err)
 				return

--- a/pkg/db/statements/addcolumn.sql
+++ b/pkg/db/statements/addcolumn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE placeholder ADD COLUMN new_column TEXT;

--- a/pkg/db/statements/addfieldsindex.sql
+++ b/pkg/db/statements/addfieldsindex.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_placeholder_field_names ON placeholder (extra_fields);

--- a/pkg/db/statements/dropfieldsindex.sql
+++ b/pkg/db/statements/dropfieldsindex.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_placeholder_field_names;

--- a/pkg/db/statements/insert.sql
+++ b/pkg/db/statements/insert.sql
@@ -1,4 +1,4 @@
-INSERT INTO placeholder(id, name, namespace, previous_id, uid, created, deleted, value)
+INSERT INTO placeholder(id, name, namespace, previous_id, uid, created, deleted, value extra_fields)
 VALUES ((SELECT COALESCE(MAX(id), 0) + 1 FROM placeholder),
         $1,
         $2,
@@ -6,4 +6,4 @@ VALUES ((SELECT COALESCE(MAX(id), 0) + 1 FROM placeholder),
         $4,
         $5,
         $6,
-        $7) RETURNING id;
+        $7 extra_vals) RETURNING id;

--- a/pkg/db/statements/list.sql
+++ b/pkg/db/statements/list.sql
@@ -1,7 +1,7 @@
 SELECT (SELECT max(id) FROM placeholder) AS max_id,
        coalesce((SELECT c.id
                  FROM compaction AS c
-                 WHERE c.name = 'placeholder'), 0)              as compaction_id,
+                 WHERE c.name = 'placeholder'), 0) as compaction_id,
        id,
        name,
        namespace,
@@ -24,7 +24,7 @@ FROM (SELECT id,
       WHERE (namespace = $1 OR $1 IS NULL)
         AND (name = $2 OR $2 IS NULL)
         AND ($3 = 0 OR id <= $3)
-        AND ($4 = 0 OR id > $4)) AS r
+        AND ($4 = 0 OR id > $4) extra_fields) AS r
 WHERE rn = 1
   AND deleted = 0
 ORDER BY id

--- a/pkg/db/statements/listafter.sql
+++ b/pkg/db/statements/listafter.sql
@@ -12,6 +12,6 @@ SELECT (SELECT max(id) FROM placeholder)           AS max_id,
        value
 FROM placeholder
 WHERE (namespace = $1 OR $1 IS NULL)
-  AND (name = $2 OR $2 IS NULL)
+  AND (name = $2 OR $2 IS NULL) extra_fields
   AND id > $3
 ORDER BY id

--- a/pkg/db/statements/sqls.go
+++ b/pkg/db/statements/sqls.go
@@ -3,19 +3,51 @@ package statements
 import (
 	"embed"
 	_ "embed"
+	"fmt"
+	"strings"
 )
 
 //go:embed *.sql
 var fs embed.FS
 
-func (s *Statements) CreateSQL() string           { return s.statements["migrate.sql"] }
-func (s *Statements) InsertSQL() string           { return s.statements["insert.sql"] }
-func (s *Statements) TableMetaSQL() string        { return s.statements["tablemeta.sql"] }
-func (s *Statements) ClearCreatedSQL() string     { return s.statements["clearcreated.sql"] }
+func (s *Statements) CreateSQL() string { return s.statements["migrate.sql"] }
+
+func (s *Statements) AddColumnSQL(name string) string {
+	return strings.Replace(s.statements["addcolumn.sql"], "new_column", strings.ReplaceAll(name, ".", "_"), 1)
+}
+
+func (s *Statements) AddFieldsIndexSQL(fields []string) string {
+	var fieldsToIndex string
+	for _, f := range fields {
+		if f != "" {
+			fieldsToIndex += fmt.Sprintf(", %s", strings.ReplaceAll(f, ".", "_"))
+		}
+	}
+
+	fieldsToIndex = strings.TrimPrefix(fieldsToIndex, ", ")
+
+	if fieldsToIndex == "" {
+		return ""
+	}
+
+	return strings.Replace(s.statements["addfieldsindex.sql"], "extra_fields", fieldsToIndex, 1)
+}
+
+func (s *Statements) DropFieldsIndexSQL() string { return s.statements["dropfieldsindex.sql"] }
+
+func (s *Statements) InsertSQL() string { return s.statements["insert.sql"] }
+
+func (s *Statements) TableMetaSQL() string { return s.statements["tablemeta.sql"] }
+
+func (s *Statements) ClearCreatedSQL() string { return s.statements["clearcreated.sql"] }
+
 func (s *Statements) UpdateCompactionSQL() string { return s.statements["updatecompaction.sql"] }
-func (s *Statements) CompactSQL() string          { return s.statements["compact.sql"] }
-func (s *Statements) listSQL() string             { return s.statements["list.sql"] }
-func (s *Statements) listAfterSQL() string        { return s.statements["listafter.sql"] }
+
+func (s *Statements) CompactSQL() string { return s.statements["compact.sql"] }
+
+func (s *Statements) listSQL() string { return s.statements["list.sql"] }
+
+func (s *Statements) listAfterSQL() string { return s.statements["listafter.sql"] }
 
 func (s *Statements) TableLockSQL() string {
 	if s.lock {

--- a/pkg/db/statements/statements.go
+++ b/pkg/db/statements/statements.go
@@ -13,7 +13,7 @@ type Statements struct {
 	lock       bool
 }
 
-func New(tableName string, lock bool) *Statements {
+func New(tableName string, extraFieldNames []string, lock bool) *Statements {
 	s := &Statements{
 		tableName:  tableName,
 		statements: map[string]string{},
@@ -31,16 +31,32 @@ func New(tableName string, lock bool) *Statements {
 		if err != nil {
 			panic("failed to read sql file: " + err.Error())
 		}
-		s.initSQL(entry.Name(), sql)
+		s.initSQL(entry.Name(), sql, extraFieldNames)
 	}
 	return s
 }
 
-func (s *Statements) initSQL(name string, sqlData []byte) {
+func (s *Statements) initSQL(name string, sqlData []byte, extraFieldNames []string) {
 	// This is hacky, sue me
 	sql := strings.ReplaceAll(string(sqlData), "'placeholder'", fmt.Sprintf(`'%s'`, s.tableName))
 	sql = strings.ReplaceAll(sql, "placeholder", fmt.Sprintf(`"%s"`, s.tableName))
 	sql = strings.ReplaceAll(sql, fmt.Sprintf(`"%s"_`, s.tableName), fmt.Sprintf(`%s_`, s.tableName))
+
+	// Add operation-specific transformations
+	switch name {
+	case "list.sql":
+		sql = strings.Replace(sql, "extra_fields", extraFieldsWithIndexOffset(extraFieldNames, 5), 1)
+	case "listafter.sql":
+		sql = strings.Replace(sql, "extra_fields", extraFieldsWithIndexOffset(extraFieldNames, 4), 1)
+	case "insert.sql":
+		var extraFields, extraVals string
+		for i, f := range extraFieldNames {
+			extraFields += fmt.Sprintf(", %s", strings.ReplaceAll(f, ".", "_"))
+			extraVals += fmt.Sprintf(",$%d", i+8)
+		}
+		sql = strings.Replace(strings.Replace(sql, "extra_fields", extraFields, 1), "extra_vals", extraVals, 1)
+	}
+
 	s.statements[name] = strings.TrimSpace(sql)
 }
 
@@ -56,4 +72,14 @@ func (s *Statements) ListAfterSQL(limit int64) string {
 		return s.listAfterSQL() + " LIMIT " + strconv.FormatInt(limit+1, 10)
 	}
 	return s.listAfterSQL()
+}
+
+func extraFieldsWithIndexOffset(extraFields []string, offset int) string {
+	var extraFieldsStr string
+	for i, f := range extraFields {
+		extraFieldsStr += fmt.Sprintf(`
+        AND (%s IS NULL OR %[1]s = $%d OR $%[2]d IS NULL)`, strings.ReplaceAll(f, ".", "_"), i+offset)
+	}
+
+	return extraFieldsStr
 }

--- a/pkg/strategy/create.go
+++ b/pkg/strategy/create.go
@@ -46,10 +46,6 @@ type PrepareForCreator interface {
 	PrepareForCreate(ctx context.Context, obj runtime.Object)
 }
 
-type NamespaceScoper interface {
-	NamespaceScoped() bool
-}
-
 var _ rest.Creater = (*CreateAdapter)(nil)
 
 func NewCreate(schema *runtime.Scheme, strategy Creater) *CreateAdapter {
@@ -184,10 +180,10 @@ func (a *CreateAdapter) Canonicalize(obj runtime.Object) {
 }
 
 func (a *CreateAdapter) NamespaceScoped() bool {
-	if o, ok := a.strategy.(NamespaceScoper); ok {
+	if o, ok := a.strategy.(types.NamespaceScoper); ok {
 		return o.NamespaceScoped()
 	}
-	if o, ok := a.strategy.New().(NamespaceScoper); ok {
+	if o, ok := a.strategy.New().(types.NamespaceScoper); ok {
 		return o.NamespaceScoped()
 	}
 	return true

--- a/pkg/strategy/list.go
+++ b/pkg/strategy/list.go
@@ -58,10 +58,10 @@ func (l *ListAdapter) List(ctx context.Context, options *metainternalversion.Lis
 }
 
 func (l *ListAdapter) NamespaceScoped() bool {
-	if o, ok := l.strategy.(NamespaceScoper); ok {
+	if o, ok := l.strategy.(types.NamespaceScoper); ok {
 		return o.NamespaceScoped()
 	}
-	if o, ok := l.strategy.New().(NamespaceScoper); ok {
+	if o, ok := l.strategy.New().(types.NamespaceScoper); ok {
 		return o.NamespaceScoped()
 	}
 	return true
@@ -75,7 +75,7 @@ func (l *ListAdapter) predicate(label labels.Selector, field fields.Selector) st
 	if attr, ok := l.strategy.(GetAttr); ok {
 		result.GetAttrs = attr.GetAttr
 	} else {
-		result.GetAttrs = defaultGetAttr(l)
+		result.GetAttrs = types.DefaultGetAttr(l)
 	}
 	return result
 }

--- a/pkg/strategy/scoper.go
+++ b/pkg/strategy/scoper.go
@@ -1,8 +1,6 @@
 package strategy
 
-type Scoper interface {
-	NamespaceScoped() bool
-}
+import "github.com/obot-platform/kinm/pkg/types"
 
 type ScoperAdapter struct {
 	strategy Newer
@@ -16,10 +14,10 @@ func NewScoper(strategy Newer) *ScoperAdapter {
 
 func (s *ScoperAdapter) NamespaceScoped() bool {
 	if s != nil {
-		if o, ok := s.strategy.(NamespaceScoper); ok {
+		if o, ok := s.strategy.(types.NamespaceScoper); ok {
 			return o.NamespaceScoped()
 		}
-		if o, ok := s.strategy.New().(NamespaceScoper); ok {
+		if o, ok := s.strategy.New().(types.NamespaceScoper); ok {
 			return o.NamespaceScoped()
 		}
 	}

--- a/pkg/strategy/watch.go
+++ b/pkg/strategy/watch.go
@@ -84,10 +84,10 @@ func (w *WatchAdapter) WatchPredicate(ctx context.Context, p storage.SelectionPr
 }
 
 func (w *WatchAdapter) NamespaceScoped() bool {
-	if o, ok := w.strategy.(NamespaceScoper); ok {
+	if o, ok := w.strategy.(types.NamespaceScoper); ok {
 		return o.NamespaceScoped()
 	}
-	if o, ok := w.strategy.New().(NamespaceScoper); ok {
+	if o, ok := w.strategy.New().(types.NamespaceScoper); ok {
 		return o.NamespaceScoped()
 	}
 	return true
@@ -101,7 +101,7 @@ func (w *WatchAdapter) predicate(label labels.Selector, field fields.Selector) s
 	if attr, ok := w.strategy.(GetAttr); ok {
 		result.GetAttrs = attr.GetAttr
 	} else {
-		result.GetAttrs = defaultGetAttr(w)
+		result.GetAttrs = types.DefaultGetAttr(w)
 	}
 	return result
 }

--- a/pkg/types/attr.go
+++ b/pkg/types/attr.go
@@ -1,14 +1,13 @@
-package strategy
+package types
 
 import (
-	"github.com/obot-platform/kinm/pkg/types"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage"
 )
 
-func defaultGetAttr(scoper NamespaceScoper) storage.AttrFunc {
+func DefaultGetAttr(scoper NamespaceScoper) storage.AttrFunc {
 	return func(obj runtime.Object) (labels.Set, fields.Set, error) {
 		ls, fs := labels.Set{}, fields.Set{}
 
@@ -28,7 +27,7 @@ func defaultGetAttr(scoper NamespaceScoper) storage.AttrFunc {
 			fs[k] = v
 		}
 
-		if f, ok := obj.(types.Fields); ok {
+		if f, ok := obj.(Fields); ok {
 			for _, field := range f.FieldNames() {
 				fs[field] = f.Get(field)
 			}

--- a/pkg/types/fields.go
+++ b/pkg/types/fields.go
@@ -8,3 +8,7 @@ type Fields interface {
 	fields.Fields
 	FieldNames() []string
 }
+
+type FieldsIndexer interface {
+	IndexFields() []string
+}

--- a/pkg/types/object.go
+++ b/pkg/types/object.go
@@ -11,6 +11,10 @@ type Object kclient.Object
 
 type ObjectList kclient.ObjectList
 
+type NamespaceScoper interface {
+	NamespaceScoped() bool
+}
+
 func MustGetListType(obj kclient.Object, scheme *runtime.Scheme) kclient.ObjectList {
 	gvk := MustGetGVK(obj, scheme)
 	gvk.Kind += "List"


### PR DESCRIPTION
Any type that implements the Fields interface will have those field names added as columns to the database. This should significantly improve the performance of lists with field selectors.

If greater performance is desired, then the types that implement the FieldIndexer interface will have the appropriate index added for the table.