### PR TITLE
fix: set deleted to 1 when clearing the created column

### DIFF
--- a/pkg/db/statements/clearcreated.sql
+++ b/pkg/db/statements/clearcreated.sql
@@ -1,5 +1,5 @@
 UPDATE placeholder
-SET created = NULL
+SET created = NULL, deleted = 1
 WHERE namespace = $1
   AND name = $2
   AND id < $3


### PR DESCRIPTION
Setting the deleted field to 1 ensures that the record will be cleaned up during compaction.