### PR TITLE
enhance: check for column existence before creating

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -40,7 +40,15 @@ func (d *db) migrate(ctx context.Context, extraColumnNames, indexFields []string
 		return err
 	}
 
+	var count int
 	for _, name := range extraColumnNames {
+		// Check if column already exists
+		if err = d.queryRowContext(ctx, d.stmt.CheckColumnSQL(name)).Scan(&count); err == nil && count > 0 {
+			// Ignore errors because we will just try to add the column.
+			// Skip adding column if it already exists
+			continue
+		}
+
 		if _, err = d.execContext(ctx, d.stmt.AddColumnSQL(name)); err != nil {
 			switch e := err.(type) {
 			case *pq.Error:

--- a/pkg/db/statements/checkcolumn.sql
+++ b/pkg/db/statements/checkcolumn.sql
@@ -1,0 +1,4 @@
+SELECT 1 FROM information_schema.columns
+WHERE table_name = 'placeholder'
+AND table_schema = COALESCE(NULLIF(current_schema(), ''), 'public')
+AND (column_name = 'new_column' OR column_name = 'new_column_lower');

--- a/pkg/db/statements/sqls.go
+++ b/pkg/db/statements/sqls.go
@@ -12,6 +12,16 @@ var fs embed.FS
 
 func (s *Statements) CreateSQL() string { return s.statements["migrate.sql"] }
 
+func (s *Statements) CheckColumnSQL(name string) string {
+	name = strings.ReplaceAll(name, ".", "_")
+	return strings.Replace(
+		strings.Replace(s.statements["checkcolumn.sql"], "new_column", name, 1),
+		// Some databases transform the column name to lowercase. Check that too.
+		"new_column_lower", strings.ToLower(name),
+		1,
+	)
+}
+
 func (s *Statements) AddColumnSQL(name string) string {
 	return strings.Replace(s.statements["addcolumn.sql"], "new_column", strings.ReplaceAll(name, ".", "_"), 1)
 }


### PR DESCRIPTION
Although we catch the "already exists" errors, an error is logged on the database side. It's better to check to not produce those errors.