### PR TITLE
Reduce and gate kinm trace volume

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
-	"fmt"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/lib/pq"
 	"github.com/obot-platform/kinm/pkg/db/errors"
 	"github.com/obot-platform/kinm/pkg/db/statements"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
+	kotel "github.com/obot-platform/kinm/pkg/otel"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -94,9 +92,6 @@ func (d *db) execContext(ctx context.Context, query string, args ...any) (sql.Re
 }
 
 func (d *db) queryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	ctx, span := tracer.Start(ctx, "dbQueryContext", trace.WithAttributes(attribute.String("query", query), attribute.String("args", fmt.Sprint(args...))))
-	defer span.End()
-
 	tx, ok := ctx.Value(txKey{}).(*sql.Tx)
 	if ok {
 		return tx.QueryContext(ctx, query, args...)
@@ -105,9 +100,6 @@ func (d *db) queryContext(ctx context.Context, query string, args ...any) (*sql.
 }
 
 func (d *db) queryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
-	ctx, span := tracer.Start(ctx, "dbQueryRowContext", trace.WithAttributes(attribute.String("query", query), attribute.String("args", fmt.Sprint(args...))))
-	defer span.End()
-
 	tx, ok := ctx.Value(txKey{}).(*sql.Tx)
 	if ok {
 		return tx.QueryRowContext(ctx, query, args...)
@@ -131,10 +123,6 @@ func (n noopTx) Commit() error {
 }
 
 func (d *db) beginTx(ctx context.Context, options *sql.TxOptions) (context.Context, tx, error) {
-	// Don't use the context here because it will look like a nested span for everything the callers does after calling this.
-	_, span := tracer.Start(ctx, "dbBeginTx")
-	defer span.End()
-
 	_, ok := ctx.Value(txKey{}).(*sql.Tx)
 	if ok {
 		// don't actually nest transactions
@@ -148,9 +136,6 @@ func (d *db) beginTx(ctx context.Context, options *sql.TxOptions) (context.Conte
 }
 
 func (d *db) get(ctx context.Context, namespace, name string) (*record, error) {
-	ctx, span := tracer.Start(ctx, "dbGet", trace.WithAttributes(attribute.String("namespace", namespace), attribute.String("name", name)))
-	defer span.End()
-
 	_, records, err := d.list(ctx, getNamespace(namespace), &name, 0, false, 0, 1, nil)
 	if err != nil {
 		return nil, err
@@ -169,7 +154,7 @@ type tableMeta struct {
 // list after=true will return all records after rev, whereas after=false it will return just the latest resourceVersion
 // for each name,namespace pair for all records <= rev
 func (d *db) list(ctx context.Context, namespace, name *string, rev int64, after bool, cont, limit int64, fieldSelector fields.Selector) (tableMeta, []record, error) {
-	ctx, span := tracer.Start(ctx, "dbList")
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "dbList")
 	defer span.End()
 
 	if cont > 0 && rev <= 0 {
@@ -231,17 +216,11 @@ func (d *db) list(ctx context.Context, namespace, name *string, rev int64, after
 }
 
 func (d *db) getTableMeta(ctx context.Context) (meta tableMeta, _ error) {
-	ctx, span := tracer.Start(ctx, "dbGetTableMeta")
-	defer span.End()
-
 	err := d.queryRowContext(ctx, d.stmt.TableMetaSQL()).Scan(&meta.ListID, &meta.CompactionID)
 	return meta, err
 }
 
 func (d *db) doList(ctx context.Context, namespace, name *string, rev int64, after bool, cont, limit int64, vals []any) (meta tableMeta, _ []record, _ error) {
-	ctx, span := tracer.Start(ctx, "dbDoList")
-	defer span.End()
-
 	var (
 		rows *sql.Rows
 		err  error
@@ -254,11 +233,9 @@ func (d *db) doList(ctx context.Context, namespace, name *string, rev int64, aft
 
 	if after {
 		vals = append([]any{namespace, name, rev}, vals...)
-		span.AddEvent("listAfterSQL")
 		rows, err = d.queryContext(ctx, d.stmt.ListAfterSQL(limit), vals...)
 	} else {
 		vals = append([]any{namespace, name, rev, cont}, vals...)
-		span.AddEvent("listSQL")
 		rows, err = d.queryContext(ctx, d.stmt.ListSQL(limit), vals...)
 	}
 	if err != nil {
@@ -287,10 +264,9 @@ func (d *db) doList(ctx context.Context, namespace, name *string, rev int64, aft
 }
 
 func (d *db) insert(ctx context.Context, rec record) (id int64, _ error) {
-	ctx, span := tracer.Start(ctx, "dbInsert")
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "dbInsert")
 	defer span.End()
 
-	span.AddEvent("beginTx")
 	ctx, tx, err := d.beginTx(ctx, &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 	})
@@ -301,7 +277,6 @@ func (d *db) insert(ctx context.Context, rec record) (id int64, _ error) {
 		_ = tx.Rollback()
 	}()
 
-	span.AddEvent("doInsert")
 	id, err = d.doInsert(ctx, rec)
 	if err != nil {
 		return 0, err
@@ -319,16 +294,12 @@ type sqlCode interface {
 }
 
 func (d *db) doInsert(ctx context.Context, rec record) (id int64, err error) {
-	ctx, span := tracer.Start(ctx, "dbDoInsert")
-	defer span.End()
-
 	if rec.vals == nil {
 		rec.vals = make([]any, len(d.extraFieldNames))
 	} else if len(rec.vals) != len(d.extraFieldNames) {
 		panic("vals must have the same length as extraFieldNames")
 	}
 
-	span.AddEvent("lockTable")
 	_, err = d.execContext(ctx, d.stmt.TableLockSQL())
 	if err != nil {
 		return 0, err
@@ -366,7 +337,6 @@ func (d *db) doInsert(ctx context.Context, rec record) (id int64, err error) {
 	}
 
 	args := append([]any{rec.name, rec.namespace, rec.previousID, rec.uid, createdAny, rec.deleted, rec.value}, rec.vals...)
-	span.AddEvent("insertSQL")
 	err = d.queryRowContext(ctx, d.stmt.InsertSQL(), args...).Scan(&id)
 	if pgErr, ok := err.(sqlError); ok && pgErr.SQLState() == "23505" {
 		return 0, errors.NewAlreadyExists(d.gvk, rec.name)
@@ -379,7 +349,7 @@ func (d *db) doInsert(ctx context.Context, rec record) (id int64, err error) {
 }
 
 func (d *db) delete(ctx context.Context, r record) (int64, error) {
-	ctx, span := tracer.Start(ctx, "dbDelete")
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "dbDelete")
 	defer span.End()
 
 	ctx, tx, err := d.beginTx(ctx, &sql.TxOptions{
@@ -404,7 +374,6 @@ func (d *db) delete(ctx context.Context, r record) (int64, error) {
 		return 0, err
 	}
 
-	span.AddEvent("clearCreatedSQL")
 	if _, err := d.execContext(ctx, d.stmt.ClearCreatedSQL(), r.namespace, r.name, id); err != nil {
 		return 0, err
 	}
@@ -413,10 +382,9 @@ func (d *db) delete(ctx context.Context, r record) (int64, error) {
 }
 
 func (d *db) compact(ctx context.Context) (resultCount int64, _ error) {
-	ctx, span := tracer.Start(ctx, "dbCompact", trace.WithAttributes(attribute.String("gvk", d.gvk.String())))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "dbCompact")
 	defer span.End()
 	for {
-		span.AddEvent("compactSQL")
 		result, err := d.execContext(ctx, d.stmt.CompactSQL())
 		if err != nil {
 			return resultCount, err
@@ -430,7 +398,6 @@ func (d *db) compact(ctx context.Context) (resultCount int64, _ error) {
 		}
 	}
 
-	span.AddEvent("updateCompactionSQL")
 	_, err := d.execContext(ctx, d.stmt.UpdateCompactionSQL())
 	return resultCount, err
 }

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -127,7 +127,7 @@ func New(ctx context.Context, sqlDB *sql.DB, gvk schema.GroupVersionKind, scheme
 }
 
 func (s *Strategy) Create(ctx context.Context, object types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyCreate", trace.WithAttributes(attribute.String("gvk", s.db.gvk.String()), attribute.String("name", object.GetName()), attribute.String("namespace", object.GetNamespace())))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyCreate", trace.WithAttributes(kotel.ObjectToAttributes(object, attribute.String("gvk", s.db.gvk.String()))...))
 	defer span.End()
 
 	if object.GetUID() == "" {
@@ -176,7 +176,7 @@ func (s *Strategy) New() types.Object {
 }
 
 func (s *Strategy) Get(ctx context.Context, namespace, name string) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyGet", trace.WithAttributes(attribute.String("gvk", s.db.gvk.String()), attribute.String("name", name), attribute.String("namespace", namespace)))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyGet", trace.WithAttributes(attribute.String("gvk", s.db.gvk.String()), attribute.String("namespace", namespace)))
 	defer span.End()
 
 	rec, err := s.db.get(ctx, namespace, name)
@@ -192,7 +192,7 @@ func (s *Strategy) Get(ctx context.Context, namespace, name string) (types.Objec
 }
 
 func (s *Strategy) Update(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyUpdate", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", s.db.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyUpdate", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", s.db.gvk.String()))...))
 	defer span.End()
 
 	defer s.broadcastChange()
@@ -257,7 +257,7 @@ func (s *Strategy) doUpdate(ctx context.Context, obj types.Object, updateGenerat
 }
 
 func (s *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyUpdateStatus", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", s.db.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyUpdateStatus", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", s.db.gvk.String()))...))
 	defer span.End()
 
 	defer s.broadcastChange()
@@ -283,7 +283,7 @@ func (s *Strategy) prepareList(opts storage.ListOptions) (storage.ListOptions, e
 }
 
 func (s *Strategy) List(ctx context.Context, namespace string, opts storage.ListOptions) (types.ObjectList, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyList", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", s.db.gvk.String()), attribute.String("namespace", namespace))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyList", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", s.db.gvk.String()), attribute.String("namespace", namespace))...))
 	defer span.End()
 
 	var (
@@ -336,7 +336,7 @@ func (s *Strategy) NewList() types.ObjectList {
 }
 
 func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyDelete", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", s.db.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyDelete", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", s.db.gvk.String()))...))
 	defer span.End()
 
 	defer s.broadcastChange()
@@ -349,7 +349,7 @@ func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, 
 }
 
 func (s *Strategy) Watch(ctx context.Context, namespace string, opts storage.ListOptions) (<-chan watch.Event, error) {
-	ctx, span := tracer.Start(ctx, "dbStrategyWatch", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", s.db.gvk.String()), attribute.String("namespace", namespace))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyWatch", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", s.db.gvk.String()), attribute.String("namespace", namespace))...))
 	defer span.End()
 
 	opts, err := s.prepareList(opts)

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -176,7 +176,11 @@ func (s *Strategy) New() types.Object {
 }
 
 func (s *Strategy) Get(ctx context.Context, namespace, name string) (types.Object, error) {
-	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyGet", trace.WithAttributes(attribute.String("gvk", s.db.gvk.String()), attribute.String("namespace", namespace)))
+	attrs := []attribute.KeyValue{attribute.String("gvk", s.db.gvk.String())}
+	if namespace != "" {
+		attrs = append(attrs, attribute.String("namespace", namespace))
+	}
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "dbStrategyGet", trace.WithAttributes(attrs...))
 	defer span.End()
 
 	rec, err := s.db.get(ctx, namespace, name)

--- a/pkg/otel/attributes.go
+++ b/pkg/otel/attributes.go
@@ -8,25 +8,38 @@ import (
 )
 
 func ListOptionsToAttributes(opts storage.ListOptions, otherAttributes ...attribute.KeyValue) []attribute.KeyValue {
-	return append(otherAttributes,
-		attribute.String("resourceVersion", opts.ResourceVersion),
-		attribute.String("continue", opts.Predicate.Continue),
+	result := append([]attribute.KeyValue{}, otherAttributes...)
+	result = append(result,
+		attribute.Bool("hasResourceVersion", opts.ResourceVersion != ""),
+		attribute.Bool("hasContinue", opts.Predicate.Continue != ""),
 		attribute.Int64("limit", opts.Predicate.Limit),
+		attribute.Bool("hasLabelSelector", hasSelector(opts.Predicate.Label)),
+		attribute.Bool("hasFieldSelector", hasSelector(opts.Predicate.Field)),
 		attribute.Bool("allowWatchBookmarks", opts.Predicate.AllowWatchBookmarks),
-		attribute.StringSlice("indexLabels", opts.Predicate.IndexLabels),
-		attribute.StringSlice("indexFields", opts.Predicate.IndexFields),
-		attribute.Stringer("labelSelector", opts.Predicate.Label),
-		attribute.Stringer("fieldSelector", opts.Predicate.Field),
-		attribute.String("resourceVersionMatch", string(opts.ResourceVersionMatch)),
+		attribute.Int("indexLabelCount", len(opts.Predicate.IndexLabels)),
+		attribute.Int("indexFieldCount", len(opts.Predicate.IndexFields)),
+		attribute.Bool("hasResourceVersionMatch", opts.ResourceVersionMatch != ""),
 		attribute.Bool("progressNotify", opts.ProgressNotify),
 		attribute.Bool("recursive", opts.Recursive),
-		attribute.Bool("sendInitialEvents", opts.SendInitialEvents == nil || *opts.SendInitialEvents),
 	)
+	if opts.SendInitialEvents != nil {
+		result = append(result, attribute.Bool("sendInitialEvents", *opts.SendInitialEvents))
+	}
+	return result
 }
 
 func ObjectToAttributes(obj types.Object, otherAttributes ...attribute.KeyValue) []attribute.KeyValue {
-	return append(otherAttributes,
-		attribute.String("name", obj.GetName()),
-		attribute.String("namespace", obj.GetNamespace()),
-	)
+	result := append([]attribute.KeyValue{}, otherAttributes...)
+	if namespace := obj.GetNamespace(); namespace != "" {
+		result = append(result, attribute.String("namespace", namespace))
+	}
+	return result
+}
+
+type stringer interface {
+	String() string
+}
+
+func hasSelector(selector stringer) bool {
+	return selector != nil && selector.String() != ""
 }

--- a/pkg/otel/level.go
+++ b/pkg/otel/level.go
@@ -1,0 +1,45 @@
+package otel
+
+import "os"
+
+type Level string
+
+const (
+	LevelOff     Level = "off"
+	LevelBasic   Level = "basic"
+	LevelVerbose Level = "verbose"
+
+	DefaultLevel = LevelOff
+)
+
+func ParseLevel(v string) Level {
+	return Level(v).normalized()
+}
+
+func CurrentLevel() Level {
+	return ParseLevel(os.Getenv("KINM_TRACE_LEVEL"))
+}
+
+func (l Level) normalized() Level {
+	switch l {
+	case LevelOff, LevelBasic, LevelVerbose:
+		return l
+	default:
+		return DefaultLevel
+	}
+}
+
+func (l Level) Enabled(min Level) bool {
+	return levelRank(l.normalized()) >= levelRank(min.normalized())
+}
+
+func levelRank(l Level) int {
+	switch l {
+	case LevelVerbose:
+		return 2
+	case LevelBasic:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/pkg/otel/spans.go
+++ b/pkg/otel/spans.go
@@ -1,0 +1,25 @@
+package otel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func StartSpanIfParent(ctx context.Context, tracer trace.Tracer, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return StartSpanLevelIfParent(ctx, tracer, LevelBasic, name, opts...)
+}
+
+func StartSpanLevelIfParent(ctx context.Context, tracer trace.Tracer, min Level, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !CurrentLevel().Enabled(min) {
+		return ctx, noop.Span{}
+	}
+	if !trace.SpanContextFromContext(ctx).IsValid() {
+		return ctx, noop.Span{}
+	}
+	if tracer == nil {
+		return ctx, noop.Span{}
+	}
+	return tracer.Start(ctx, name, opts...)
+}

--- a/pkg/strategy/create.go
+++ b/pkg/strategy/create.go
@@ -79,9 +79,6 @@ func (a *CreateAdapter) New() runtime.Object {
 }
 
 func (a *CreateAdapter) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "create")
-	defer span.End()
-
 	retriesRenaming := a.generateNameRetryLimit
 	original := obj.DeepCopyObject()
 

--- a/pkg/strategy/delete.go
+++ b/pkg/strategy/delete.go
@@ -47,9 +47,6 @@ func (a *DeleteAdapter) Recognizes(gvk schema.GroupVersionKind) bool {
 }
 
 func (a *DeleteAdapter) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, "delete")
-	defer span.End()
-
 	ns, _ := genericapirequest.NamespaceFrom(ctx)
 	obj, err := a.strategy.Get(ctx, ns, name)
 	if err != nil {

--- a/pkg/strategy/get.go
+++ b/pkg/strategy/get.go
@@ -27,9 +27,6 @@ type GetAdapter struct {
 }
 
 func (a *GetAdapter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "get")
-	defer span.End()
-
 	ns, _ := request.NamespaceFrom(ctx)
 	return a.strategy.Get(ctx, ns, name)
 }

--- a/pkg/strategy/list.go
+++ b/pkg/strategy/list.go
@@ -42,9 +42,6 @@ func NewList(strategy Lister) *ListAdapter {
 }
 
 func (l *ListAdapter) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "list")
-	defer span.End()
-
 	label := labels.Everything()
 	if options != nil && options.LabelSelector != nil {
 		label = options.LabelSelector

--- a/pkg/strategy/opts.go
+++ b/pkg/strategy/opts.go
@@ -1,13 +1,10 @@
 package strategy
 
 import (
-	"go.opentelemetry.io/otel"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var tracer = otel.Tracer("kinm/strategy")
 
 func ToListOpts(namespace string, opts storage.ListOptions) *kclient.ListOptions {
 	return &kclient.ListOptions{

--- a/pkg/strategy/remote/remote.go
+++ b/pkg/strategy/remote/remote.go
@@ -44,7 +44,7 @@ func NewRemote(obj types.Object, c kclient.WithWatch) (*Remote, error) {
 }
 
 func (r *Remote) Create(ctx context.Context, object types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "create", trace.WithAttributes(kotel.ObjectToAttributes(object, attribute.String("gvk", r.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "create", trace.WithAttributes(kotel.ObjectToAttributes(object, attribute.String("gvk", r.gvk.String()))...))
 	defer span.End()
 
 	return object, r.c.Create(ctx, object)
@@ -60,21 +60,21 @@ func (r *Remote) Get(ctx context.Context, namespace, name string) (types.Object,
 }
 
 func (r *Remote) Update(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "update", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", r.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "update", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", r.gvk.String()))...))
 	defer span.End()
 
 	return obj, r.c.Update(ctx, obj)
 }
 
 func (r *Remote) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "updateStatus", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", r.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "updateStatus", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", r.gvk.String()))...))
 	defer span.End()
 
 	return obj, r.c.Status().Update(ctx, obj)
 }
 
 func (r *Remote) GetToList(ctx context.Context, namespace, name string) (types.ObjectList, error) {
-	ctx, span := tracer.Start(ctx, "getToList", trace.WithAttributes(kotel.ObjectToAttributes(r.obj, attribute.String("gvk", r.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "getToList", trace.WithAttributes(kotel.ObjectToAttributes(r.obj, attribute.String("gvk", r.gvk.String()))...))
 	defer span.End()
 
 	list := r.NewList()
@@ -88,7 +88,7 @@ func (r *Remote) GetToList(ctx context.Context, namespace, name string) (types.O
 }
 
 func (r *Remote) List(ctx context.Context, namespace string, opts storage.ListOptions) (types.ObjectList, error) {
-	ctx, span := tracer.Start(ctx, "list", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", r.gvk.String()), attribute.String("namespace", namespace))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "list", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", r.gvk.String()), attribute.String("namespace", namespace))...))
 	defer span.End()
 
 	list := r.NewList()
@@ -100,14 +100,14 @@ func (r *Remote) NewList() types.ObjectList {
 }
 
 func (r *Remote) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "delete", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", r.gvk.String()))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "delete", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", r.gvk.String()))...))
 	defer span.End()
 
 	return obj, r.c.Delete(ctx, obj)
 }
 
 func (r *Remote) Watch(ctx context.Context, namespace string, opts storage.ListOptions) (<-chan watch.Event, error) {
-	ctx, span := tracer.Start(ctx, "watch", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", r.gvk.String()), attribute.String("namespace", namespace))...))
+	ctx, span := kotel.StartSpanIfParent(ctx, tracer, "watch", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", r.gvk.String()), attribute.String("namespace", namespace))...))
 	defer span.End()
 
 	list := r.NewList()

--- a/pkg/strategy/status.go
+++ b/pkg/strategy/status.go
@@ -46,23 +46,14 @@ func (s *Status) Destroy() {
 }
 
 func (s *Status) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "getStatus")
-	defer span.End()
-
 	return s.get.Get(ctx, name, options)
 }
 
 func (s *Status) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, "updateStatus")
-	defer span.End()
-
 	return s.update.update(ctx, true, name, objInfo, createValidation, updateValidation, false, options)
 }
 
 func (s *Status) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
-	ctx, span := tracer.Start(ctx, "convertToTable")
-	defer span.End()
-
 	if o, ok := s.strategy.(rest.TableConvertor); ok {
 		return o.ConvertToTable(ctx, object, tableOptions)
 	}

--- a/pkg/strategy/table.go
+++ b/pkg/strategy/table.go
@@ -22,9 +22,6 @@ func NewTable(strategy any) *TableAdapter {
 }
 
 func (t *TableAdapter) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
-	ctx, span := tracer.Start(ctx, "convertToTable")
-	defer span.End()
-
 	if o, ok := t.strategy.(rest.TableConvertor); ok && o != nil {
 		return o.ConvertToTable(ctx, object, tableOptions)
 	}

--- a/pkg/strategy/translation/translation.go
+++ b/pkg/strategy/translation/translation.go
@@ -104,7 +104,7 @@ func (t *Strategy) toPublic(ctx context.Context, obj runtime.Object, err error, 
 }
 
 func (t *Strategy) Create(ctx context.Context, object types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "translateCreate", trace.WithAttributes(kotel.ObjectToAttributes(object, attribute.String("gvk", t.pubGVK.String()))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateCreate", trace.WithAttributes(kotel.ObjectToAttributes(object, attribute.String("gvk", t.pubGVK.String()))...))
 	defer span.End()
 
 	newObj, err := t.fromPublic(ctx, object)
@@ -120,7 +120,7 @@ func (t *Strategy) New() types.Object {
 }
 
 func (t *Strategy) Get(ctx context.Context, namespace, name string) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "translateGet", trace.WithAttributes(kotel.ObjectToAttributes(t.translator.NewPublic(), attribute.String("gvk", t.pubGVK.String()))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateGet", trace.WithAttributes(kotel.ObjectToAttributes(t.translator.NewPublic(), attribute.String("gvk", t.pubGVK.String()))...))
 	defer span.End()
 
 	newNamespace, newName, err := t.translator.FromPublicName(ctx, namespace, name)
@@ -141,7 +141,7 @@ func (t *Strategy) fromPublic(ctx context.Context, obj types.Object) (types.Obje
 }
 
 func (t *Strategy) Update(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "translateUpdate", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", t.pubGVK.String()))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateUpdate", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", t.pubGVK.String()))...))
 	defer span.End()
 
 	newObj, err := t.fromPublic(ctx, obj)
@@ -153,7 +153,7 @@ func (t *Strategy) Update(ctx context.Context, obj types.Object) (types.Object, 
 }
 
 func (t *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "translateUpdateStatus", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", t.pubGVK.String()))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateUpdateStatus", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", t.pubGVK.String()))...))
 	defer span.End()
 
 	newObj, err := t.fromPublic(ctx, obj)
@@ -206,7 +206,7 @@ func (t *Strategy) toPublicList(ctx context.Context, obj types.ObjectList) (type
 }
 
 func (t *Strategy) List(ctx context.Context, namespace string, opts storage.ListOptions) (types.ObjectList, error) {
-	ctx, span := tracer.Start(ctx, "translateList", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", t.pubGVK.String()), attribute.String("namespace", namespace))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateList", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", t.pubGVK.String()), attribute.String("namespace", namespace))...))
 	defer span.End()
 
 	namespace, opts, err := t.translateListOpts(ctx, namespace, opts)
@@ -225,7 +225,7 @@ func (t *Strategy) NewList() types.ObjectList {
 }
 
 func (t *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
-	ctx, span := tracer.Start(ctx, "translateDelete", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", t.pubGVK.String()))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateDelete", trace.WithAttributes(kotel.ObjectToAttributes(obj, attribute.String("gvk", t.pubGVK.String()))...))
 	defer span.End()
 
 	newObj, err := t.fromPublic(ctx, obj)
@@ -262,7 +262,7 @@ func (t *Strategy) translateListOpts(ctx context.Context, namespace string, opts
 }
 
 func (t *Strategy) Watch(ctx context.Context, namespace string, opts storage.ListOptions) (<-chan watch.Event, error) {
-	ctx, span := tracer.Start(ctx, "translateWatch", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", t.pubGVK.String()), attribute.String("namespace", namespace))...))
+	ctx, span := kotel.StartSpanLevelIfParent(ctx, tracer, kotel.LevelVerbose, "translateWatch", trace.WithAttributes(kotel.ListOptionsToAttributes(opts, attribute.String("gvk", t.pubGVK.String()), attribute.String("namespace", namespace))...))
 	defer span.End()
 
 	namespace, newOpts, err := t.translateListOpts(ctx, namespace, opts)

--- a/pkg/strategy/update.go
+++ b/pkg/strategy/update.go
@@ -96,8 +96,6 @@ func (a *UpdateAdapter) WarningsOnUpdate(ctx context.Context, obj, old runtime.O
 }
 
 func (a *UpdateAdapter) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, "update")
-	defer span.End()
 	return a.update(ctx, a.status, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
 }
 

--- a/pkg/strategy/watch.go
+++ b/pkg/strategy/watch.go
@@ -48,9 +48,6 @@ func NewWatch(strategy Watcher) *WatchAdapter {
 }
 
 func (w *WatchAdapter) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
-	ctx, span := tracer.Start(ctx, "watch")
-	defer span.End()
-
 	label := labels.Everything()
 	if options != nil && options.LabelSelector != nil {
 		label = options.LabelSelector


### PR DESCRIPTION
Remove the noisiest OTEL instrumentation from kinm and make the
remaining spans opt-in. This drops raw SQL and argument attributes,
removes redundant adapter and DB helper spans, and replaces
high-cardinality list and watch attributes with coarse flags and
counts.

Add KINM_TRACE_LEVEL with off, basic, and verbose levels and default
it to off. Spans in this package now only start when that level
allows them and the incoming context already carries a parent span,
which keeps standalone background usage quiet while preserving HTTP
request traces when enabled.
