### PR TITLE
fix: use subquery in compaction statement

### DIFF
--- a/pkg/db/statements/compact.sql
+++ b/pkg/db/statements/compact.sql
@@ -11,7 +11,7 @@ DELETE FROM placeholder WHERE id in (
                    FROM compaction
                    WHERE name = 'placeholder')
               , 0)
-          )
+          ) AS subquery
     WHERE deleted = 1 OR (rn > 1 AND created IS NULL) OR (previous_id IS NULL AND created IS NULL)
     ORDER BY id
     LIMIT 500


### PR DESCRIPTION
Older version of postgres (we tested with version 15) expect there to be a subquery in the compaction statement, and all compaction fails.

Testing with new versions of Postgres as well as sqlite continue to work as expected.